### PR TITLE
Support unknown exposure_program value of 0

### DIFF
--- a/lib/exexif/decode.ex
+++ b/lib/exexif/decode.ex
@@ -113,6 +113,7 @@ defmodule Exexif.Decode do
   defp resolution(2), do: "Pixels/in"
   defp resolution(3), do: "Pixels/cm"
 
+  defp exposure_program(0), do: "Unknown"
   defp exposure_program(1), do: "Manual"
   defp exposure_program(2), do: "Program AE"
   defp exposure_program(3), do: "Aperture-priority AE"


### PR DESCRIPTION
I have an image that produced the following error

```
iex(1)> d = File.read!("test.jpg")
<<255, 216, 255, 225, 95, 204, 69, 120, 105, 102, 0, 0, 73, 73, 42, 0, 8, 0, 0,
  0, 12, 0, 15, 1, 2, 0, 6, 0, 0, 0, 158, 0, 0, 0, 16, 1, 2, 0, 14, 0, 0, 0,
  164, 0, 0, 0, 18, 1, 3, 0, ...>>

iex(2)> {:ok, info} = Exexif.exif_from_jpeg_buffer(d)
** (FunctionClauseError) no function clause matching in Exexif.Decode.exposure_program/1

    The following arguments were given to Exexif.Decode.exposure_program/1:

        # 1
        0

    Attempted function clauses (showing 9 out of 9):

        defp exposure_program(1)
        defp exposure_program(2)
        defp exposure_program(3)
        defp exposure_program(4)
        defp exposure_program(5)
        defp exposure_program(6)
        defp exposure_program(7)
        defp exposure_program(8)
        defp exposure_program(9)

    (exexif) lib/exexif/decode.ex:116: Exexif.Decode.exposure_program/1
    (exexif) lib/exexif/decode.ex:28: Exexif.Decode.tag/3
    (exexif) lib/exexif.ex:111: Exexif.read_tags/5
    (exexif) lib/exexif.ex:113: Exexif.read_tags/5
    (exexif) lib/exexif.ex:67: Exexif.read_exif/1
iex(2)>
```

The attached commit fixes this problem. Sorry if it doesn't make sense, this is the first line of Elixir I've ever written.

I can upload the image somewhere if necessary