### PR TITLE
Change extract_thumbnail to patten match only with :exif exists

### DIFF
--- a/lib/exexif.ex
+++ b/lib/exexif.ex
@@ -137,7 +137,7 @@ defmodule Exexif do
     |> extract_thumbnail
   end
 
-  defp extract_thumbnail(result) do
+  defp extract_thumbnail(%{:exif => _} = result) do
     exif_keys = Map.keys(result.exif)
     result =  if Enum.all?(Exexif.Data.Thumbnail.fields, fn e -> Enum.any?(exif_keys, & &1 == e) end) do
                 Map.put(

--- a/lib/exexif.ex
+++ b/lib/exexif.ex
@@ -137,8 +137,8 @@ defmodule Exexif do
     |> extract_thumbnail
   end
 
-  defp extract_thumbnail(%{:exif => _} = result) do
-    exif_keys = Map.keys(result.exif)
+  defp extract_thumbnail(%{exif: exif} = result) do 
+    exif_keys = Map.keys(exif)
     result =  if Enum.all?(Exexif.Data.Thumbnail.fields, fn e -> Enum.any?(exif_keys, & &1 == e) end) do
                 Map.put(
                   result,


### PR DESCRIPTION
when iterating over my photo collection I kept getting this error.

```
    ** (EXIT) an exception was raised:
        ** (KeyError) key :exif not found in: %{}
            (exexif) lib/exexif.ex:143: Exexif.extract_thumbnail/1
            (exexif) lib/exexif.ex:67: Exexif.read_exif/1
            (phorg) lib/phorg.ex:67: anonymous fn/1 in Phorg.start/2
            (elixir) lib/enum.ex:675: Enum."-each/2-lists^foreach/1-0-"/2
            (elixir) lib/enum.ex:675: Enum.each/2
            (phorg) lib/phorg.ex:64: Phorg.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4


```

I wasn't able to track down what the faulty image was but changing extract_thumbnail/1 to match against results only if :exif existed solved the problem

Existing tests pass

This is my 2nd ever change to an elixir lib so I apologise if this makes no sense. 

Feel free to ignore ;)

